### PR TITLE
Consider also highway=road and "fixme" as substring

### DIFF
--- a/checks/name_via
+++ b/checks/name_via
@@ -20,6 +20,6 @@ OR
 /* names composed only of UPPER/lower case letters and some non-alphabetic characters */
 tags->'name' ~'^[[:upper:][:space:][:punct:]]+$|^[[:lower:][:space:][:punct:]]+$'
 OR
-tags -> 'name' ~~ any(ARRAY['P.zza %', 'p.zza %', 'P.za %', 'p.za %', 'V.le %', 'fixme', 'FIXME', 'Fixme', 'FIX ME','VIA %'])
+tags -> 'name' ~~ any(ARRAY['P.zza %', 'p.zza %', 'P.za %', 'p.za %', 'V.le %', '%fixme%', '%FIXME%', '%Fixme%', '%FIX ME%',' VIA %'])
 );
 

--- a/checks/name_via
+++ b/checks/name_via
@@ -14,7 +14,8 @@ WHERE tags ? 'name' AND tags->'highway' IN (
 'trunk',
 'trunk_link'
 'motorway',
-'motorway_link') AND
+'motorway_link',
+'road') AND
 (tags->'name' ~'[[:upper:]]{2,}[[:lower:]]|[[:lower:]][[:upper:]]'
 OR
 /* names composed only of UPPER/lower case letters and some non-alphabetic characters */


### PR DESCRIPTION
This pull request is to change the query to search also all errors in the ways of type highway=road and to search for the word "fixme" (and its variations) as substring and not only as full name.